### PR TITLE
-- doppelte charsetangabe im head

### DIFF
--- a/files/www/freifunk/cgi-bin/status
+++ b/files/www/freifunk/cgi-bin/status
@@ -4,7 +4,6 @@
 <html lang="de">
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <%
 name="$(uci -q get freifunk.@settings[0].name)"


### PR DESCRIPTION
 (als meta charset und im content type) mag der validator.w3.org das irgendwie nicht