### PR TITLE
++ scipts.js extended (missing upgrade-functions)

### DIFF
--- a/files/www/lan/scripts.js
+++ b/files/www/lan/scripts.js
@@ -2103,3 +2103,32 @@ function apply() {
 		});
 	}
 }
+
+/* imported from upgrade.js */
+
+function restore_firmware() {
+	if (!confirm("Sollen alle Einstellungen zur\xFCckgesetzt werden?")) {
+		return;
+	}
+
+	send("/cgi-bin/upgrade", { func : 'restore_firmware' }, function(text) {
+		setText('msg', text);
+	});
+}
+function lookup_upgrade() {
+	setText('msg', 'Versuche Updateserver zu erreichen. Bitte warten ...');
+	send("/cgi-bin/upgrade", { func : 'lookup_upgrade' }, function(text) {
+		setText('msg', text);
+	});
+}
+
+function lookup_and_apply_upgrade() {
+	if (!confirm("Soll ein Update durchgef\xFChrt werden?")) {
+		return;
+	}
+
+	setText('msg', 'Versuche Updateserver zu erreichen. Bitte warten ...');
+	send("/cgi-bin/upgrade", { func : 'lookup_and_apply_upgrade' }, function(text) {
+		setText('msg', text);
+	});
+}


### PR DESCRIPTION
should fix https://github.com/ffbsee/ffbsee-firmware/issues/72